### PR TITLE
Change sorting so that it works with Python 3.x too

### DIFF
--- a/script/tblextr.py
+++ b/script/tblextr.py
@@ -84,8 +84,7 @@ def print_tbl(outfile):
 
   out = open(outfile, 'w')
 
-  keys = var_table.keys()
-  keys.sort(key=int)
+  keys = sorted(var_table.keys(), key=int)
 
   entry = var_table[keys[0]]
   list1 = []


### PR DESCRIPTION
Change sorting so that it not only works with Python 2.7, but with 3.x too.
Without the modification, running with Python 3.x results in an error:

```
Traceback (most recent call last):
  File "/opt/rocm/bin/tblextr.py", line 120, in <module>
    ret = print_tbl(outfile)                         
  File "/opt/rocm/bin/tblextr.py", line 90, in print_tbl
    keys.sort(key=int)                                                          
AttributeError: 'dict_keys' object has no attribute 'sort'                   
```
