### PR TITLE
Enable use of custom metrics definitions w/ rocprof

### DIFF
--- a/bin/rpl_run.sh
+++ b/bin/rpl_run.sh
@@ -133,6 +133,7 @@ usage() {
   echo "      The data directory is renoving autonatically if the directory is matching the temporary one, which is the default."
   echo "  -t <temporary directory> - to change the temporary directory [/tmp]"
   echo "      By changing the temporary directory you can prevent removing the profiling data from /tmp or enable removing from not '/tmp' directory."
+  echo "  -m <metric file> - file defining custom metrics to use in-place of defaults."
   echo ""
   echo "  --basenames <on|off> - to turn on/off truncating of the kernel full function names till the base ones [off]"
   echo "  --timestamp <on|off> - to turn on/off the kernel disoatches timestamps, dispatch/begin/end/complete [off]"
@@ -258,6 +259,9 @@ while [ 1 ] ; do
     if [ "$OUTPUT_DIR" = "-" ] ; then
       DATA_PATH=$TMP_DIR
     fi
+  elif [ "$1" = "-m" ] ; then
+    unset ROCP_METRICS
+    export ROCP_METRICS="$2"
   elif [ "$1" = "--list-basic" ] ; then
     export ROCP_INFO=b
     eval "$PKG_DIR/tool/ctrl"


### PR DESCRIPTION
This functionality currently is difficult to achieve without creating a copy of the `run_rpl.sh` script in the correct directory (`/opt/rocm/rocprofiler/bin/`), but the documentation seems to imply that it should be possible to use custom metrics based off hardware counters not currently exposed in rocprof.  

This change simply adds a flag to `rpl_run.sh` that, if supplied, will override the default metrics file.