### PR TITLE
Protect application arguments with spaces.

### DIFF
--- a/bin/rpl_run.sh
+++ b/bin/rpl_run.sh
@@ -347,7 +347,12 @@ else
   csv_output=$RUN_DIR/${input_base}.csv
 fi
 
-APP_CMD=$*
+APP_CMD=""
+for i in `seq 1 $#`
+do
+  eval "arg=\${$i}"
+  APP_CMD=$APP_CMD" "\"$arg\"
+done
 
 echo "RPL: profiling '$APP_CMD'"
 echo "RPL: input file '$INPUT_FILE'"


### PR DESCRIPTION
Issue:
`exe -g "2 2 1"` was interpreted as `exe -g 2 2 1`
Now
`"exe" "-g" "2 2 1"`