### PR TITLE
Interface proposal : pull request 3

### DIFF
--- a/test/tool/tool.cpp
+++ b/test/tool/tool.cpp
@@ -337,19 +337,21 @@ unsigned align_size(unsigned size, unsigned alignment) {
   return ((size + alignment - 1) & ~(alignment - 1));
 }
 
+void metric_flush_cb(const char *name, uint64_t result){
+  fprintf(result_file_handle, "  %s ", name);
+  fprintf(result_file_handle, "(%lu)\n", result);
+}
 // Output profiling results for input features
 void output_results(const context_entry_t* entry, const char* label) {
-  FILE* file = entry->file_handle;
   const rocprofiler_feature_t* features = entry->features;
   const unsigned feature_count = entry->feature_count;
 
   for (unsigned i = 0; i < feature_count; ++i) {
     const rocprofiler_feature_t* p = &features[i];
-    fprintf(file, "  %s ", p->name);
     switch (p->data.kind) {
       // Output metrics results
       case ROCPROFILER_DATA_KIND_INT64:
-        fprintf(file, "(%lu)\n", p->data.result_int64);
+        metric_flush_cb(p->name, p->data.result_int64);
         break;
       default:
         fprintf(stderr, "RPL-tool: undefined data kind(%u)\n", p->data.kind);

--- a/test/tool/tool.cpp
+++ b/test/tool/tool.cpp
@@ -1108,7 +1108,6 @@ extern "C" PUBLIC_API void OnLoadToolProp(rocprofiler_settings_t* settings)
 
   // Getting traces
   const auto traces_list = xml->GetNodes("top.trace");
-  if (traces_list.size() > 1) fatal("ROCProfiler: only one trace supported at a time");
 
   const unsigned feature_count = metrics_vec.size() + traces_list.size();
   rocprofiler_feature_t* features = new rocprofiler_feature_t[feature_count];


### PR DESCRIPTION
This is the third pull request for the proposal for a plugin interface for the rocprof command. In this pull request, the signatures of the flushing functions are standardized for every API/kind of event.

The signatures of all flushing function are now of this kind : void \<API\>_flush_cb(\<API\>_trace_entry_t *entry)
Where \<API\> is the kind of event or API that is traced and  \<API\>_trace_entry_t is a wrapping data structure containing the payloads of the traced events.

Relative to the second pull request, this one starts at commit 65161e2