### PR TITLE
Interface proposal : pull request 5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,10 +145,12 @@ install ( TARGETS ${ROCPROFILER_TARGET} LIBRARY DESTINATION ${DEST_NAME}/lib )
 install ( FILES
           ${CMAKE_CURRENT_SOURCE_DIR}/inc/rocprofiler.h
           ${CMAKE_CURRENT_SOURCE_DIR}/src/core/activity.h
+          ${CMAKE_CURRENT_SOURCE_DIR}/inc/rocprofiler_trace_entries.h
           DESTINATION ${DEST_NAME}/include )
 install ( FILES
           ${CMAKE_CURRENT_SOURCE_DIR}/inc/rocprofiler.h
           ${CMAKE_CURRENT_SOURCE_DIR}/src/core/activity.h
+          ${CMAKE_CURRENT_SOURCE_DIR}/inc/rocprofiler_trace_entries.h
           DESTINATION include/${DEST_NAME} )
 # rpl_run.sh tblextr.py txt2xml.sh
 install ( FILES

--- a/bin/rpl_run.sh
+++ b/bin/rpl_run.sh
@@ -276,6 +276,7 @@ run() {
       error "Could not find roctracer_plugin_lib.so library at '$PLUGIN_PATH'"
     fi    
     export PLUGIN_LIB="enabled"
+    export PLUGIN_PATH
     export ROCPROFILER_PLUGIN_LIB="$PLUGIN_PATH/rocprofiler_plugin_lib.so"
     export ROCTRACER_PLUGIN_LIB="$PLUGIN_PATH/roctracer_plugin_lib.so"
   fi

--- a/bin/rpl_run.sh
+++ b/bin/rpl_run.sh
@@ -50,6 +50,7 @@ KFD_TRACE=0
 HSA_TRACE=0
 SYS_TRACE=0
 HIP_TRACE=0
+OUTPUT_PLUGIN=0
 
 # Generate stats
 GEN_STATS=0
@@ -185,6 +186,7 @@ usage() {
   echo "        </parameters>"
   echo "      </trace>"
   echo ""
+  echo "  --output-plugin <plugin directory> - to enable the use of a plugin"
   echo "  --trace-start <on|off> - to enable tracing on start [on]"
   echo "  --trace-period <dealy:length:rate> - to enable trace with initial delay, with periodic sample length and rate"
   echo "    Supported time formats: <number(m|s|ms|us)>"
@@ -263,6 +265,20 @@ run() {
     OUTPUT_LIST="$OUTPUT_LIST $ROCP_OUTPUT_DIR/results.txt"
   fi
 
+  if [ $OUTPUT_PLUGIN = 1 ] ; then
+    if [ ! -e "$PLUGIN_PATH" ] ; then
+      error "'$PLUGIN_PATH' directory does not exist"
+    fi
+    if [ ! -f "$PLUGIN_PATH/rocprofiler_plugin_lib.so" ] ; then
+      error "Could not find rocprofiler_plugin_lib.so library at '$PLUGIN_PATH'"
+    fi
+    if [ ! -e "$PLUGIN_PATH/roctracer_plugin_lib.so" ] ; then
+      error "Could not find roctracer_plugin_lib.so library at '$PLUGIN_PATH'"
+    fi    
+    export PLUGIN_LIB="enabled"
+    export ROCPROFILER_PLUGIN_LIB="$PLUGIN_PATH/rocprofiler_plugin_lib.so"
+    export ROCTRACER_PLUGIN_LIB="$PLUGIN_PATH/roctracer_plugin_lib.so"
+  fi
   API_TRACE=""
   MY_LD_PRELOAD=""
   if [ "$ROCTX_TRACE" = 1 ] ; then
@@ -436,6 +452,9 @@ while [ 1 ] ; do
     export ROCP_TIMESTAMP_ON=1
     GEN_STATS=1
     HIP_TRACE=1
+  elif [ "$1" = "--output-plugin" ] ; then
+    OUTPUT_PLUGIN=1
+    PLUGIN_PATH="$2"
   elif [ "$1" = "--trace-start" ] ; then
     if [ "$2" = "off" ] ; then
       export ROCP_CTRL_RATE="-1"

--- a/inc/rocprofiler_trace_entries.h
+++ b/inc/rocprofiler_trace_entries.h
@@ -9,4 +9,28 @@ struct metric_trace_entry_t {
   uint64_t result;
 };
 
+struct kernel_trace_entry_t {
+  uint32_t dispatch;
+  uint32_t gpu_id;
+  uint32_t queue_id;
+  uint64_t queue_index;
+  uint32_t pid;
+  uint32_t tid;
+  uint32_t grid_size;
+  uint32_t workgroup_size;
+  uint32_t lds_size;
+  uint32_t scratch_size;
+  uint32_t vgpr;
+  uint32_t sgpr;
+  uint32_t fbarrier_count;
+  uint64_t signal_handle;
+  uint64_t object;
+  const char* kernel_name;
+  bool record;
+  uint64_t dispatch_time;
+  uint64_t begin;
+  uint64_t end;
+  uint64_t complete;
+};
+
 #endif

--- a/inc/rocprofiler_trace_entries.h
+++ b/inc/rocprofiler_trace_entries.h
@@ -1,0 +1,12 @@
+#ifndef INC_ROCTRACER_TRACE_ENTRIES_H_
+#define INC_ROCTRACER_TRACE_ENTRIES_H_
+
+#include <cstdint>
+
+struct metric_trace_entry_t {
+  uint32_t dispatch;
+  const char* name;
+  uint64_t result;
+};
+
+#endif

--- a/test/tool/tool.cpp
+++ b/test/tool/tool.cpp
@@ -376,30 +376,6 @@ void output_group(const context_entry_t* entry, const char* label) {
   }
 }
 
-struct kernel_trace_entry_t {
-  uint32_t dispatch;
-  uint32_t gpu_id;
-  uint32_t queue_id;
-  uint64_t queue_index;
-  uint32_t pid;
-  uint32_t tid;
-  uint32_t grid_size;
-  uint32_t workgroup_size;
-  uint32_t lds_size;
-  uint32_t scratch_size;
-  uint32_t vgpr;
-  uint32_t sgpr;
-  uint32_t fbarrier_count;
-  uint64_t signal_handle;
-  uint64_t object;
-  const char* kernel_name;
-  bool record;
-  uint64_t dispatch_time;
-  uint64_t begin;
-  uint64_t end;
-  uint64_t complete;
-};
-
 void kernel_flush_cb(kernel_trace_entry_t* entry){
   fprintf(result_file_handle, "dispatch[%u], gpu-id(%u), queue-id(%u), queue-index(%lu), pid(%u), tid(%u), grd(%u), wgr(%u), lds(%u), scr(%u), vgpr(%u), sgpr(%u), fbar(%u), sig(0x%lx), obj(0x%lx), kernel-name(\"%s\")",
     entry->dispatch,

--- a/test/tool/tool.cpp
+++ b/test/tool/tool.cpp
@@ -337,19 +337,21 @@ unsigned align_size(unsigned size, unsigned alignment) {
   return ((size + alignment - 1) & ~(alignment - 1));
 }
 
+void metric_flush_cb(const char *name, uint64_t result){
+  fprintf(result_file_handle, "  %s ", name);
+  fprintf(result_file_handle, "(%lu)\n", result);
+}
 // Output profiling results for input features
 void output_results(const context_entry_t* entry, const char* label) {
-  FILE* file = entry->file_handle;
   const rocprofiler_feature_t* features = entry->features;
   const unsigned feature_count = entry->feature_count;
 
   for (unsigned i = 0; i < feature_count; ++i) {
     const rocprofiler_feature_t* p = &features[i];
-    fprintf(file, "  %s ", p->name);
     switch (p->data.kind) {
       // Output metrics results
       case ROCPROFILER_DATA_KIND_INT64:
-        fprintf(file, "(%lu)\n", p->data.result_int64);
+        metric_flush_cb(p->name, p->data.result_int64);
         break;
       default:
         fprintf(stderr, "RPL-tool: undefined data kind(%u)\n", p->data.kind);

--- a/test/tool/tool.cpp
+++ b/test/tool/tool.cpp
@@ -49,6 +49,7 @@ THE SOFTWARE.
 #include <vector>
 
 #include "inc/rocprofiler.h"
+#include "inc/rocprofiler_trace_entries.h"
 #include "util/hsa_rsrc_factory.h"
 #include "util/xml.h"
 
@@ -336,12 +337,6 @@ struct trace_data_arg_t {
 unsigned align_size(unsigned size, unsigned alignment) {
   return ((size + alignment - 1) & ~(alignment - 1));
 }
-
-struct metric_trace_entry_t {
-  uint32_t dispatch;
-  const char* name;
-  uint64_t result;
-};
 
 void metric_flush_cb(metric_trace_entry_t *entry){
   fprintf(result_file_handle, "  %s ", entry->name);

--- a/test/tool/tool.cpp
+++ b/test/tool/tool.cpp
@@ -1108,7 +1108,6 @@ extern "C" PUBLIC_API void OnLoadToolProp(rocprofiler_settings_t* settings)
 
   // Getting traces
   const auto traces_list = xml->GetNodes("top.trace");
-  if (traces_list.size() > 1) fatal("ROCProfiler: only one trace supported at a time");
 
   const unsigned feature_count = metrics_vec.size() + traces_list.size();
   rocprofiler_feature_t* features = new rocprofiler_feature_t[feature_count];


### PR DESCRIPTION
This is the last pull request for the interface proposal. It adds the --output-plugin option in rocprof and instructions to overload user-defined flushing functions (that respect some specifications). 

An example of a CTF plugin can be found here : https://github.com/dorsal-lab/rocprofiler_ctf_plugin/tree/rocm-4.3.x-PR5 (be sure to use the rocm-4.3.x-PR5 branch for tests).

Relative to the fourth pull request, this one starts at commit 86d43f3