### PR TITLE
Infinite recursion fix

### DIFF
--- a/src/core/rocprofiler.cpp
+++ b/src/core/rocprofiler.cpp
@@ -111,7 +111,7 @@ decltype(hsa_executable_destroy)* hsa_executable_destroy_fn;
 ::HsaApiTable* kHsaApiTable;
 
 void SaveHsaApi(::HsaApiTable* table) {
-  util::HsaRsrcFactory::InitHsaApiTable(table);
+  util::HsaRsrcFactory::Instance().InitHsaApiTable(table);
 
   kHsaApiTable = table;
   hsa_queue_create_fn = table->core_->hsa_queue_create_fn;

--- a/src/util/hsa_rsrc_factory.cpp
+++ b/src/util/hsa_rsrc_factory.cpp
@@ -184,7 +184,6 @@ HsaRsrcFactory::~HsaRsrcFactory() {
 void HsaRsrcFactory::InitHsaApiTable(HsaApiTable* table) {
   std::lock_guard<mutex_t> lck(mutex_);
 
-  if (hsa_api_.hsa_init == NULL) {
     if (table != NULL) {
       hsa_api_.hsa_init = table->core_->hsa_init_fn;
       hsa_api_.hsa_shut_down = table->core_->hsa_shut_down_fn;
@@ -268,7 +267,6 @@ void HsaRsrcFactory::InitHsaApiTable(HsaApiTable* table) {
       hsa_api_.hsa_amd_profiling_get_async_copy_time = hsa_amd_profiling_get_async_copy_time;
       hsa_api_.hsa_amd_profiling_get_dispatch_time = hsa_amd_profiling_get_dispatch_time;
     }
-  }
 }
 
 hsa_status_t HsaRsrcFactory::LoadAqlProfileLib(aqlprofile_pfn_t* api) {

--- a/src/util/hsa_rsrc_factory.h
+++ b/src/util/hsa_rsrc_factory.h
@@ -414,7 +414,7 @@ class HsaRsrcFactory {
   static const char* GetKernelNameRef(uint64_t addr);
 
   // Initialize HSA API table
-  void static InitHsaApiTable(HsaApiTable* table);
+  void InitHsaApiTable(HsaApiTable* table);
   static const hsa_pfn_t* HsaApi() { return &hsa_api_; }
 
   // Return AqlProfile API table


### PR DESCRIPTION
I noticed that rocm-4.5.2 tag is one commit ahead of rocm-4.5.x branch and that commit contains only newly added comments. Therefore, I decide to post the PR based on the rocm-4.5.x.

The main change is that `hsa_api_` becomes a member rather than a static member of `HsaRsrcFactory`. This ensures that `hsa_api_` will always be initialized with the public HSA function entries (so that one can use  `HsaRsrcFactory` object to call HSA functions) and then one can reset `hsa_api_` with internal HSA implementations for intercepting HSA calls.

This fixes #66 for both collecting performance counters and getting code object URI from roctracer.