### PR TITLE
github issue#74 fix

### DIFF
--- a/src/core/context_pool.h
+++ b/src/core/context_pool.h
@@ -156,7 +156,9 @@ class ContextPool {
       entry_t* entry = reinterpret_cast<entry_t*>(ptr);
       Context::Destroy(entry->context);
     }
-    free(array_);
+    if (constructed_) {
+      free(array_);
+    }
   }
 
   char* GetArrayPtr(const uint32_t& index) { return array_ + (index % array_size_bytes_); }

--- a/src/core/intercept_queue.cpp
+++ b/src/core/intercept_queue.cpp
@@ -29,7 +29,7 @@ void InterceptQueue::HsaIntercept(HsaApiTable* table) {
 }
 
 InterceptQueue::mutex_t InterceptQueue::mutex_;
-rocprofiler_queue_callbacks_t InterceptQueue::callbacks_ = {};
+rocprofiler_queue_callbacks_t InterceptQueue::callbacks_ = {NULL,NULL,NULL};
 void* InterceptQueue::callback_data_ = NULL;
 std::atomic<rocprofiler_callback_t> InterceptQueue::dispatch_callback_{NULL};
 InterceptQueue::obj_map_t InterceptQueue::obj_map_{};


### PR DESCRIPTION
Intercept Queue callbacks are checked for null. If the user forgets to initialize one of them, random code could be called. That leads to very tricky memory corruption bugs. I met the condition when the program restarted in the context pool destructor.